### PR TITLE
Add \orcids command to add support for multiple ORCIDs

### DIFF
--- a/Rmarkdown.Rmd
+++ b/Rmarkdown.Rmd
@@ -37,7 +37,7 @@ if (!file.exists(rmarkdown::metadata$csl)) {
     
 \keywords{keywords go here; use 3-5 keywords; semicolons in between; same font as abstract; authors designate their own keywords rather than choosing from a menu.}
 \correspondingauthor{Jason Pierce, Department of Psychology, University of Rugby, Spaceman Park, Rugby, CV21 1XX, UK. Email: Jason.Pierce@Rugby.ac.uk.}
-\orcid{https://orcid.org/0000-1234-5678-9999}
+\orcids{https://orcid.org/0000-1234-5678-9999;https://orcid.org/0000-5678-1234-9999}
 \citationinfo{Other, A.N., Kramer, W.K., \& Pierce, J. (2022). Article title goes here. \textit{Language Development Research, 2}(1), XX–XX. \url{https://doi.org/10.34xxx/xxxx-xxxx}}
 
 

--- a/Rmarkdown.Rmd
+++ b/Rmarkdown.Rmd
@@ -38,6 +38,9 @@ if (!file.exists(rmarkdown::metadata$csl)) {
 \keywords{keywords go here; use 3-5 keywords; semicolons in between; same font as abstract; authors designate their own keywords rather than choosing from a menu.}
 \correspondingauthor{Jason Pierce, Department of Psychology, University of Rugby, Spaceman Park, Rugby, CV21 1XX, UK. Email: Jason.Pierce@Rugby.ac.uk.}
 \orcids{https://orcid.org/0000-1234-5678-9999;https://orcid.org/0000-5678-1234-9999}
+<!-- For a single ORCID, something like:
+\orcid{https://orcid.org/0000-1234-5678-9999}
+-->
 \citationinfo{Other, A.N., Kramer, W.K., \& Pierce, J. (2022). Article title goes here. \textit{Language Development Research, 2}(1), XX–XX. \url{https://doi.org/10.34xxx/xxxx-xxxx}}
 
 

--- a/ldr-article.cls
+++ b/ldr-article.cls
@@ -94,7 +94,7 @@
 % for a single ORCID
 \newcommand{\orcid}[1]{\titlepagefontsize\textbf{ORCID ID: }\url{#1} \\[\baselineskip]}
 
-% for a multiple ORCIDs
+% for a multiple ORCIDs delimited by semicolon ;
 \newcommand{\orcids}[1]{\titlepagefontsize\textbf{ORCID IDs: }\orcidlist{#1} \\[\baselineskip]}
 \NewDocumentCommand{\orcidlist}{ >{\SplitList{;}} m }{%
   \ProcessList{#1}{\orciditem}%

--- a/ldr-article.cls
+++ b/ldr-article.cls
@@ -17,6 +17,9 @@
 % Support for different font colors
 \usepackage{xcolor}
 
+% Allow use of SplitList for \orcids command
+\usepackage{xparse}
+
 % Redefine the page margins
 \RequirePackage[left=2.5cm,right=2.5cm,bottom=4cm,top=1.5cm,headsep=2.5cm,includehead]{geometry}
 
@@ -88,7 +91,17 @@
 
 \newcommand{\correspondingauthor}[1]{\titlepagefontsize\textbf{Corresponding author: }#1 \\[\baselineskip]}
 
+% for a single ORCID
 \newcommand{\orcid}[1]{\titlepagefontsize\textbf{ORCID ID: }\url{#1} \\[\baselineskip]}
+
+% for a multiple ORCIDs
+\newcommand{\orcids}[1]{\titlepagefontsize\textbf{ORCID IDs: }\orcidlist{#1} \\[\baselineskip]}
+\NewDocumentCommand{\orcidlist}{ >{\SplitList{;}} m }{%
+  \ProcessList{#1}{\orciditem}%
+}
+\NewDocumentCommand{\orciditem}{m}{%
+  \url{#1} % a space follows
+}
 
 \newcommand{\citationinfo}[1]{\titlepagefontsize\textbf{Citation: }#1 \\[\baselineskip]%
 % The end of title page is after the end of the citation info. We add a page break and return to the normal font size

--- a/ldr-article.cls
+++ b/ldr-article.cls
@@ -100,7 +100,7 @@
   \ProcessList{#1}{\orciditem}%
 }
 \NewDocumentCommand{\orciditem}{m}{%
-  \url{#1} % a space follows
+  \url{#1}; % a space follows
 }
 
 \newcommand{\citationinfo}[1]{\titlepagefontsize\textbf{Citation: }#1 \\[\baselineskip]%

--- a/main.tex
+++ b/main.tex
@@ -43,6 +43,8 @@ University of Rugby, UK
     \keywords{keywords go here; use 3-5 keywords; semicolons in between; same font as abstract; authors designate their own keywords rather than choosing from a menu.}
     \correspondingauthor{Jason Pierce, Department of Psychology, University of Rugby, Spaceman Park, Rugby, CV21 1XX, UK. Email: Jason.Pierce@Rugby.ac.uk.}
     \orcid{https://orcid.org/0000-1234-5678-9999}
+    % for multiple ORCIDs, use \orcids and URLs separated by semicolons, e.g.:
+    %\orcids{https://orcid.org/0000-1234-5678-9999;https://orcid.org/0000-5678-1234-9999}
     \citationinfo{Other, A.N., Kramer, W.K., \& Pierce, J. (2022). Article title goes here. \textit{Language Development Research, 2}(1), XX–XX. \url{https://doi.org/10.34xxx/xxxx-xxxx}}
 
 


### PR DESCRIPTION
`\orcids` takes a list of ORCID urls, delimited by semicolons, following the apparent pattern in published articles, e.g.
```
\orcids{https://orcid.org/0000-1234-5678-9999;https://orcid.org/0000-5678-1234-9999}
```
